### PR TITLE
Update page table schema

### DIFF
--- a/parse_mysqldump.py
+++ b/parse_mysqldump.py
@@ -14,9 +14,9 @@ PAGELINKS_PARSER=re.compile(r'^(?P<row0>[0-9]+?),(?P<row1>[0-9]+?),(?P<row2>\'.*
 REDIRECT_PARSER=re.compile(r'^(?P<row0>[0-9]+?),(?P<row1>-?[0-9]+?),(?P<row2>\'.*?\'?),(?P<row3>\'.*?\'?),(?P<row4>\'.*?\'?)$')
 CATEGORY_PARSER=re.compile(r'^(?P<row0>[0-9]+?),(?P<row1>\'.*?\'?),(?P<row2>[0-9]+?),(?P<row3>[0-9]+?),(?P<row4>[0-9]+?)$')
 PAGE_PROPS_PARSER=re.compile(r'^([0-9]+),(\'.*?\'),(\'.*?\'),(\'[0-9\ \-:]+\'),(\'\'),(\'.*?\'),(\'.*?\')$')
-PAGE_PARSER=re.compile((r'^(?P<row0>[0-9]+?),(?P<row1>[0-9]+?),(?P<row2>\'.*?\'?),(?P<row3>\'.*?\'?),(?P<row4>[0-9]+?),(?P<row5>[0-9]+?),(?P<row6>[0-9]?),'
-    r'(?P<row7>[0-9\.]+?),(?P<row8>\'.*?\'?),(?P<row9>(?P<row9val>\'.*?\'?)|(?P<row9null>NULL)),(?P<row10>[0-9]+?),(?P<row11>[0-9]+?),'
-    r'(?P<row12>(?P<row12val>\'.*?\'?)|(?P<row12null>NULL)),(?P<row13>(?P<row13val>\'.*?\'?)|(?P<row13null>NULL))$'))
+PAGE_PARSER=re.compile((r'^(?P<row0>[0-9]+?),(?P<row1>[0-9]+?),(?P<row2>\'.*?\'?),(?P<row3>\'.*?\'?),(?P<row4>[0-9]+?),(?P<row5>[0-9]+?),(?P<row6>[0-9\.]+?),'
+    r'(?P<row7>\'.*?\'?),(?P<row8>(?P<row8val>\'.*?\'?)|(?P<row8null>NULL)),(?P<row9>[0-9]+?),(?P<row10>[0-9]+?),'
+    r'(?P<row11>(?P<row11val>\'.*?\'?)|(?P<row11null>NULL)),(?P<row12>(?P<row12val>\'.*?\'?)|(?P<row12null>NULL))$'))
 
 """
 # page
@@ -24,7 +24,6 @@ PAGE_PARSER=re.compile((r'^(?P<row0>[0-9]+?),(?P<row1>[0-9]+?),(?P<row2>\'.*?\'?
 `page_namespace` int(11) NOT NULL DEFAULT '0',
 `page_title` varbinary(255) NOT NULL DEFAULT '',
 `page_restrictions` tinyblob NOT NULL,
-`page_counter` bigint(20) unsigned NOT NULL DEFAULT '0',
 `page_is_redirect` tinyint(1) unsigned NOT NULL DEFAULT '0',
 `page_is_new` tinyint(1) unsigned NOT NULL DEFAULT '0',
 `page_random` double unsigned NOT NULL DEFAULT '0',
@@ -52,7 +51,7 @@ FILETYPE_PROPS=dict(
         redirect=FILEPROPS(REDIRECT_PARSER, 5, (0, 1, 2)),
         category=FILEPROPS(CATEGORY_PARSER, 5, (0, 1, 2, 3, 4)),
         page_props=FILEPROPS(PAGE_PROPS_PARSER, 7, (0, 1)),
-        page=FILEPROPS(PAGE_PARSER, 14, (0, 1, 2, 5, 11, 12, 13)),
+        page=FILEPROPS(PAGE_PARSER, 13, (0, 1, 2, 4, 10, 11, 12)),
         )
 
 #VALUE_PARSER=re.compile(r'\(([0-9]+),(\'.*?\'),(\'.*?\'),(\'[0-9\ \-:]+\'),(\'\'),(\'.*?\'),(\'.*?\')\)')


### PR DESCRIPTION
Hey,
I just found this little tool and it's working pretty well so far, but the page table schema seems to be from an older version of WikiMedia and therefore doesn't work anymore. I just updated the page regex to work with the current schema. Not sure if some of the others are also outdated, pagelinks seems to work at least.

Also is there a reason why you are making the closing `'` for strings optional in the regexes? This seems to break sites like `Kagrra,` that end in a `,`.